### PR TITLE
Use Hash Router instead

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Router from 'react-router/BrowserRouter';
+import Router from 'react-router/HashRouter';
 import Match from 'react-router/Match';
 import ReactDOM from 'react-dom';
 import Introduction from './Introduction';


### PR DESCRIPTION
We don't control the way github pages routes things, so using hash router makes more sense, at least till this is hosted somewhere else.